### PR TITLE
Add fallback polling with exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ flowchart TB
   READY[onReady] --> LOGIN[Cloud Login]
   LOGIN --> POLL[pollOnce]
   POLL --> UPSERT[Update Objects + States]
+  UPSERT --> BACKOFF{All offline?}
+  BACKOFF -- yes --> INC[Increase interval up to 1h then 12:00/00:00]
+  BACKOFF -- no --> RESET[Reset to base interval]
+  INC --> POLL
+  RESET --> POLL
 
   APPLYBTN[Apply Button] --> ROUTER[applyRouter]
   ROUTER --> API[updateThermostat]

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -179,6 +179,20 @@ Werte beginnen mit **heutigem Tag**.
 - Cloud‑Verbindungsüberwachung
 - Fehlerbehandlung bei Apply
 - Sauberes Shutdown
+- Fallback-Polling (automatisches Backoff, siehe unten)
+
+---
+
+## 🔁 Fallback-Polling
+
+Wenn die Cloud nicht erreichbar ist oder **alle** Thermostate offline sind, reduziert der Adapter automatisch die Abfragehäufigkeit:
+
+| Phase | Verhalten |
+| ----- | --------- |
+| Normal | Abfrage im konfigurierten Intervall (Standard: 60 s) |
+| Backoff | Bei jedem weiteren Fehler verdoppelt sich das Intervall (60 s → 120 s → 240 s → … → 1 h) |
+| Fester Zeitplan | Nach Erreichen von 1 h wechselt die Abfrage auf einen festen Zeitplan um **12:00** und **00:00** |
+| Wiederherstellung | Sobald mindestens ein Thermostat wieder online ist, wird das Intervall auf den konfigurierten Wert zurückgesetzt |
 
 ---
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -179,6 +179,20 @@ Values start with **today**.
 - Cloud connection monitoring
 - Apply error handling
 - Graceful shutdown
+- Fallback polling (automatic backoff, see below)
+
+---
+
+## 🔁 Fallback Polling
+
+When the cloud is unreachable or **all** thermostats are offline, the adapter automatically reduces polling frequency to conserve resources:
+
+| Phase | Behavior |
+| ----- | -------- |
+| Normal | Polls at the configured interval (default: 60 s) |
+| Backoff | On each consecutive failure the interval doubles (60 s → 120 s → 240 s → … → 1 h) |
+| Fixed schedule | After reaching 1 h, polling switches to a fixed schedule at **12:00** and **00:00** |
+| Recovery | As soon as at least one thermostat is online again, the interval resets to the configured value |
 
 ---
 

--- a/lib/time.js
+++ b/lib/time.js
@@ -1,7 +1,7 @@
 /* eslint-disable jsdoc/require-jsdoc */
 'use strict';
 
-// Incoming Cloud → Thermostat Anzeigezeit (lokal, ohne Z)
+// Incoming Cloud → Thermostat display time (local, no Z suffix)
 function toThermostatLocalNoZFromAny(value, timeZoneSec) {
 	if (!value) {
 		return '';


### PR DESCRIPTION
When the cloud is unreachable or all thermostats are offline, the poll interval now doubles on each failure (up to 1 h). Once the 1 h ceiling is reached the adapter switches to a fixed schedule polling at 12:00 and 00:00. As soon as at least one device comes back online the interval resets to the configured base value.

Also translates remaining German code comments to English (main.js, lib/time.js) and documents the new behaviour in docs/en, docs/de and the main README.

https://claude.ai/code/session_01KguxVNrw9xfiQ36Nx24EjU