### PR TITLE
Fix ioBroker object hierarchy (review feedback mcm1957)

### DIFF
--- a/lib/objects.js
+++ b/lib/objects.js
@@ -3,6 +3,24 @@
 
 const { safeId } = require('./util');
 
+// Create or migrate a container object (folder / channel / device).
+// If the object already exists with a different type or name it is corrected
+// in-place so that existing installations are migrated automatically.
+async function ensureContainer(adapter, id, type, name, native = {}) {
+	const cur = await adapter.safeGetObject(id);
+	if (!cur) {
+		await adapter.safeSetObject(id, { type, common: { name }, native });
+		return;
+	}
+	if (cur.type !== type || cur.common?.name !== name) {
+		await adapter.safeSetObject(id, {
+			...cur,
+			type,
+			common: { ...(cur.common || {}), name },
+		});
+	}
+}
+
 async function ensureGroupObjects(adapter, group) {
 	const groupId = String(group?.GroupId ?? '');
 	if (!groupId) {
@@ -14,47 +32,21 @@ async function ensureGroupObjects(adapter, group) {
 
 	const groupDev = `groups.${safeId(groupId)}`;
 
-	await adapter.safeSetObjectNotExists(groupDev, {
-		type: 'device',
-		common: { name: groupName },
-		native: { groupId },
-	});
-
-	await adapter.safeSetObjectNotExists(`${groupDev}.thermostats`, {
-		type: 'channel',
-		common: { name: 'Thermostats' },
-		native: {},
-	});
-
-	const cur = await adapter.safeGetObject(groupDev);
-	if (cur && cur.common?.name !== groupName) {
-		await adapter.safeSetObject(groupDev, {
-			...cur,
-			common: { ...(cur.common || {}), name: groupName },
-		});
-	}
+	// folder (was device) – only one device per tree allowed
+	await ensureContainer(adapter, groupDev, 'folder', groupName, { groupId });
+	// folder (was channel) – channels may not contain devices
+	await ensureContainer(adapter, `${groupDev}.thermostats`, 'folder', 'Thermostats');
 }
 
 async function ensureThermostatObjects(adapter, devId, native, thermostatName) {
-	await adapter.safeSetObjectNotExists(devId, {
-		type: 'device',
-		common: { name: thermostatName },
-		native,
-	});
-
-	const cur = await adapter.safeGetObject(devId);
-	if (cur && cur.common?.name !== thermostatName) {
-		await adapter.safeSetObject(devId, {
-			...cur,
-			common: { ...(cur.common || {}), name: thermostatName },
-		});
-	}
+	// Thermostat is the single device in the hierarchy
+	await ensureContainer(adapter, devId, 'device', thermostatName, native);
 
 	const ensureState = async (id, common) => {
 		await adapter.safeSetObjectNotExists(id, { type: 'state', common, native: {} });
 	};
 
-	// core read-only states
+	// core read-only states (directly under device)
 	await ensureState(`${devId}.online`, {
 		name: 'Online',
 		type: 'boolean',
@@ -77,6 +69,8 @@ async function ensureThermostatObjects(adapter, devId, native, thermostatName) {
 		write: false,
 	});
 
+	// temperature channel
+	await ensureContainer(adapter, `${devId}.temperature`, 'channel', 'Temperature');
 	await ensureState(`${devId}.temperature.room`, {
 		name: 'Room temperature',
 		type: 'number',
@@ -94,6 +88,8 @@ async function ensureThermostatObjects(adapter, devId, native, thermostatName) {
 		write: false,
 	});
 
+	// setpoint channel
+	await ensureContainer(adapter, `${devId}.setpoint`, 'channel', 'Setpoints');
 	await ensureState(`${devId}.setpoint.manual`, {
 		name: 'Manual setpoint',
 		type: 'number',
@@ -208,11 +204,7 @@ async function ensureApplyObjects(adapter, devId) {
 	await adapter.safeSetObjectNotExists(`${devId}.apply`, { type: 'channel', common: { name: 'Apply' }, native: {} });
 
 	// schedule
-	await adapter.safeSetObjectNotExists(`${devId}.apply.schedule`, {
-		type: 'channel',
-		common: { name: 'Schedule mode' },
-		native: {},
-	});
+	await ensureContainer(adapter, `${devId}.apply.schedule`, 'folder', 'Schedule mode');
 	await ensureState(`${devId}.apply.schedule.apply`, {
 		name: 'Apply schedule mode (RegulationMode=1)',
 		type: 'boolean',
@@ -223,11 +215,7 @@ async function ensureApplyObjects(adapter, devId) {
 	});
 
 	// comfort
-	await adapter.safeSetObjectNotExists(`${devId}.apply.comfort`, {
-		type: 'channel',
-		common: { name: 'Comfort mode' },
-		native: {},
-	});
+	await ensureContainer(adapter, `${devId}.apply.comfort`, 'folder', 'Comfort mode');
 	await ensureState(`${devId}.apply.comfort.setpoint`, {
 		name: 'Comfort setpoint',
 		type: 'number',
@@ -258,11 +246,7 @@ async function ensureApplyObjects(adapter, devId) {
 	});
 
 	// manual
-	await adapter.safeSetObjectNotExists(`${devId}.apply.manual`, {
-		type: 'channel',
-		common: { name: 'Manual mode' },
-		native: {},
-	});
+	await ensureContainer(adapter, `${devId}.apply.manual`, 'folder', 'Manual mode');
 	await ensureState(`${devId}.apply.manual.setpoint`, {
 		name: 'Manual setpoint',
 		type: 'number',
@@ -283,11 +267,7 @@ async function ensureApplyObjects(adapter, devId) {
 	});
 
 	// boost
-	await adapter.safeSetObjectNotExists(`${devId}.apply.boost`, {
-		type: 'channel',
-		common: { name: 'Boost mode' },
-		native: {},
-	});
+	await ensureContainer(adapter, `${devId}.apply.boost`, 'folder', 'Boost mode');
 	await ensureState(`${devId}.apply.boost.durationMinutes`, {
 		name: 'Boost duration (minutes)',
 		type: 'number',
@@ -308,11 +288,7 @@ async function ensureApplyObjects(adapter, devId) {
 	});
 
 	// eco
-	await adapter.safeSetObjectNotExists(`${devId}.apply.eco`, {
-		type: 'channel',
-		common: { name: 'Eco mode' },
-		native: {},
-	});
+	await ensureContainer(adapter, `${devId}.apply.eco`, 'folder', 'Eco mode');
 	await ensureState(`${devId}.apply.eco.apply`, {
 		name: 'Apply eco mode (RegulationMode=9)',
 		type: 'boolean',
@@ -323,11 +299,7 @@ async function ensureApplyObjects(adapter, devId) {
 	});
 
 	// name
-	await adapter.safeSetObjectNotExists(`${devId}.apply.name`, {
-		type: 'channel',
-		common: { name: 'Thermostat name' },
-		native: {},
-	});
+	await ensureContainer(adapter, `${devId}.apply.name`, 'folder', 'Thermostat name');
 	await ensureState(`${devId}.apply.name.value`, {
 		name: 'New thermostat name',
 		type: 'string',
@@ -345,11 +317,7 @@ async function ensureApplyObjects(adapter, devId) {
 	});
 
 	// vacation (write via apply)
-	await adapter.safeSetObjectNotExists(`${devId}.apply.vacation`, {
-		type: 'channel',
-		common: { name: 'Vacation' },
-		native: {},
-	});
+	await ensureContainer(adapter, `${devId}.apply.vacation`, 'folder', 'Vacation');
 	await ensureState(`${devId}.apply.vacation.enabled`, {
 		name: 'Vacation enabled',
 		type: 'boolean',
@@ -393,6 +361,7 @@ async function ensureApplyObjects(adapter, devId) {
 }
 
 module.exports = {
+	ensureContainer,
 	ensureGroupObjects,
 	ensureThermostatObjects,
 	ensureApplyObjects,

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const { numToC } = require('./util');
+const { ensureContainer } = require('./objects');
 
 async function writeThermostatStates(adapter, devId, t, { comfortEndLocal, boostEndLocal }) {
 	adapter.safeSetState(`${devId}.online`, { val: Boolean(t?.Online), ack: true });
@@ -97,13 +98,13 @@ async function writeScheduleStates(adapter, devId, schedule) {
 		}
 
 		const dayCh = `${devId}.schedule.day${wd}`;
-		await adapter.safeSetObjectNotExists(dayCh, { type: 'channel', common: { name: `Day ${wd}` }, native: {} });
+		await ensureContainer(adapter, dayCh, 'folder', `Day ${wd}`);
 
 		const events = Array.isArray(day.Events) ? day.Events : [];
 		for (let i = 0; i < events.length; i++) {
 			const ev = events[i];
 			const evCh = `${dayCh}.event${i}`;
-			await adapter.safeSetObjectNotExists(evCh, { type: 'channel', common: { name: `Event ${i}` }, native: {} });
+			await ensureContainer(adapter, evCh, 'folder', `Event ${i}`);
 
 			await ensureState(`${evCh}.type`, {
 				name: 'ScheduleType',

--- a/main.js
+++ b/main.js
@@ -4,18 +4,19 @@
 // schlueter-thermostat
 // Cloud-only adapter for OJ Microline / Schlüter OWD5/OCD5
 //
-// Structure:
-// groups.<GroupId>              (device, name = GroupName)
-//   .thermostats                (channel)
-//     .<ThermostatId>           (device, name = ThermostatName)
-//        .temperature.*         (read-only)
-//        .setpoint.*            (read-only)
-//        .regulationMode        (read-only)
-//        .endTime.*             (read-only; shown as thermostat-local no-Z)
-//        .vacation.*            (read-only)
-//        .schedule.*            (read-only)
-//        .energy.*              (read-only)
-//        .apply.*               (writeable controls; apply-only)
+// Object hierarchy  (folder → folder → folder → device → channel → state):
+// groups                        (folder)
+//   .<GroupId>                  (folder, name = GroupName)
+//     .thermostats              (folder)
+//       .<ThermostatId>         (device, name = ThermostatName)
+//          .temperature         (channel)  → room, floor
+//          .setpoint            (channel)  → manual, comfort
+//          .regulationMode      (state, read-only)
+//          .endTime             (channel)  → comfort, boost
+//          .vacation            (channel)  → enabled, begin, end, temperature
+//          .schedule            (channel)  → day<N> (folder) → event<N> (folder)
+//          .energy              (channel)  → count, value0 …
+//          .apply               (channel)  → <mode> (folder) → states
 //
 // Robustness:
 // - Poll interval min 10s, clamp to Node max timer
@@ -35,7 +36,7 @@ const utils = require('@iobroker/adapter-core');
 const { OJClient } = require('./lib/oj-client');
 const { safeId } = require('./lib/util');
 
-const { ensureGroupObjects, ensureThermostatObjects, ensureApplyObjects } = require('./lib/objects');
+const { ensureContainer, ensureGroupObjects, ensureThermostatObjects, ensureApplyObjects } = require('./lib/objects');
 const { toThermostatLocalNoZFromAny } = require('./lib/time');
 const {
 	writeThermostatStates,
@@ -336,7 +337,7 @@ class SchlueterThermostat extends utils.Adapter {
 			return;
 		}
 
-		await this.safeSetObjectNotExists('groups', { type: 'channel', common: { name: 'Groups' }, native: {} });
+		await ensureContainer(this, 'groups', 'folder', 'Groups');
 
 		// Cleanup legacy object tree from old versions (optional via config)
 		if (this.config.legacyCleanup === true) {
@@ -356,8 +357,8 @@ class SchlueterThermostat extends utils.Adapter {
 
 		await this.pollOnce();
 
-		// Subscribe ONLY apply buttons
-		this.subscribeStates('groups.*.thermostats.*.apply.*.apply');
+		// Subscribe all writable states under apply folders (buttons + values)
+		this.subscribeStates('groups.*.thermostats.*.apply.*.*');
 
 		this._scheduleNextPoll();
 	}
@@ -628,8 +629,9 @@ class SchlueterThermostat extends utils.Adapter {
 			return;
 		}
 
-		// only apply buttons
+		// Writable value states (e.g. setpoint, durationMinutes): acknowledge receipt
 		if (!id.endsWith('.apply')) {
+			this.safeSetState(id, { val: state.val, ack: true });
 			return;
 		}
 


### PR DESCRIPTION
Address all structural issues from ioBroker.repositories PR #5544:

1. Object hierarchy: enforce device → channel → state rule
   - groups.<GroupId>: device → folder
   - groups.<GroupId>.thermostats: channel → folder
   - <ThermostatId> remains the single device per tree
   - apply sub-containers (comfort, manual, boost, …): channel → folder
   - schedule day/event containers: channel → folder

2. Missing intermediate objects:
   - Add temperature channel (parent for room/floor states)
   - Add setpoint channel (parent for manual/comfort states)

3. Writable states now subscribed and acknowledged:
   - Subscribe pattern broadened to groups.*.thermostats.*.apply.*.*
   - Non-button value states (setpoint, duration, etc.) are acked on receipt so the adapter signals it received the data

4. Migration: ensureContainer() helper reads existing objects and corrects their type in-place, so upgrades work automatically.

https://claude.ai/code/session_01KguxVNrw9xfiQ36Nx24EjU